### PR TITLE
Interpret version field according to spec

### DIFF
--- a/Codec/Archive/Zip/Conduit/Internal.hs
+++ b/Codec/Archive/Zip/Conduit/Internal.hs
@@ -1,5 +1,5 @@
 module Codec.Archive.Zip.Conduit.Internal
-  ( zipVersion
+  ( osVersion, zipVersion
   , zipError
   , idConduit
   , sizeCRC
@@ -15,13 +15,17 @@ import qualified Data.ByteString as BS
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Internal as CI
 import           Data.Digest.CRC32 (crc32Update)
-import           Data.Word (Word16, Word32, Word64)
+import           Data.Word (Word8, Word16, Word32, Word64)
 
 import           Codec.Archive.Zip.Conduit.Types
 
--- |The version of this zip program, really just rough indicator of compatibility
-zipVersion :: Word16
+-- | The version of this zip program, really just rough indicator of compatibility
+zipVersion :: Word8
 zipVersion = 48
+
+-- | The OS this implementation tries to be compatible to
+osVersion :: Word8
+osVersion = 0 -- DOS
 
 zipError :: MonadThrow m => String -> m a
 zipError = throwM . ZipError

--- a/Codec/Archive/Zip/Conduit/UnZip.hs
+++ b/Codec/Archive/Zip/Conduit/UnZip.hs
@@ -151,8 +151,8 @@ unZipStream = next where
   centralBody 0x06054b50 = EndOfCentralDirectory <$> endDirectory
   centralBody sig = fail $ "Unknown header signature: " ++ show sig
   fileHeader = do
-    G.getWord8 -- OS Version
     ver <- G.getWord8
+    G.getWord8 -- OS Version
     when (ver > zipVersion) $ fail $ "Unsupported version: " ++ show ver
     gpf <- G.getWord16le
     -- when (gpf .&. complement (bit 1 .|. bit 2 .|. bit 3) /= 0) $ fail $ "Unsupported flags: " ++ show gpf

--- a/Codec/Archive/Zip/Conduit/UnZip.hs
+++ b/Codec/Archive/Zip/Conduit/UnZip.hs
@@ -151,7 +151,8 @@ unZipStream = next where
   centralBody 0x06054b50 = EndOfCentralDirectory <$> endDirectory
   centralBody sig = fail $ "Unknown header signature: " ++ show sig
   fileHeader = do
-    ver <- G.getWord16le
+    G.getWord8 -- OS Version
+    ver <- G.getWord8
     when (ver > zipVersion) $ fail $ "Unsupported version: " ++ show ver
     gpf <- G.getWord16le
     -- when (gpf .&. complement (bit 1 .|. bit 2 .|. bit 3) /= 0) $ fail $ "Unsupported flags: " ++ show gpf

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -165,7 +165,8 @@ zipStream ZipOptions{..} = execStateC 0 $ do
           l64 = z64 ?* 16 + o64 ?* 8
           a64 = z64 || o64
       P.putWord32le 0x02014b50
-      P.putWord16le zipVersion
+      P.putWord8 osVersion
+      P.putWord8 zipVersion
       P.putWord16le $ if a64 then 45 else 20
       common
       P.putWord32le crc
@@ -192,7 +193,8 @@ zipStream ZipOptions{..} = execStateC 0 $ do
     when z64 $ output $ do
       P.putWord32le 0x06064b50 -- zip64 end
       P.putWord64le 44 -- length of this record
-      P.putWord16le zipVersion
+      P.putWord8 osVersion
+      P.putWord8 zipVersion
       P.putWord16le 45
       P.putWord32le 0 -- disk
       P.putWord32le 0 -- central disk

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -129,7 +129,8 @@ zipStream ZipOptions{..} = execStateC 0 $ do
     off <- get
     output $ do
       P.putWord32le 0x04034b50
-      P.putWord16le $ if z64 then 45 else 20
+      P.putWord8 $ if z64 then 45 else 20
+      P.putWord8 osVersion
       common
       P.putWord32le $ fromMaybe 0 mcrc
       P.putWord32le $ if z64 then maxBound32 else maybe 0 fromIntegral csiz
@@ -165,9 +166,10 @@ zipStream ZipOptions{..} = execStateC 0 $ do
           l64 = z64 ?* 16 + o64 ?* 8
           a64 = z64 || o64
       P.putWord32le 0x02014b50
-      P.putWord8 osVersion
       P.putWord8 zipVersion
-      P.putWord16le $ if a64 then 45 else 20
+      P.putWord8 osVersion
+      P.putWord8 $ if a64 then 45 else 20
+      P.putWord8 osVersion
       common
       P.putWord32le crc
       P.putWord32le $ if z64 then maxBound32 else fromIntegral csz
@@ -193,9 +195,10 @@ zipStream ZipOptions{..} = execStateC 0 $ do
     when z64 $ output $ do
       P.putWord32le 0x06064b50 -- zip64 end
       P.putWord64le 44 -- length of this record
-      P.putWord8 osVersion
       P.putWord8 zipVersion
-      P.putWord16le 45
+      P.putWord8 osVersion
+      P.putWord8 45
+      P.putWord8 osVersion
       P.putWord32le 0 -- disk
       P.putWord32le 0 -- central disk
       P.putWord64le cnt


### PR DESCRIPTION
According to the [specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) the 2 byte long version field in the ZIP file header and central directory record is to be interpreted as two separate numbers – one specifying which OS the archive is trying to be compatible to, and one which specifies the minimum version number.

Currently the implementation interprets both numbers as one 16-bit word, which just happens to work, if the OS specifier is DOS (which is mapped to 0).

---

I believe we can simply ignore the OS specifier (which is what this PR does) and label archives we create as DOS-compatible (analogous to the behaviour of the `zip`-utility on *NIX)