### PR TITLE
Handle filename encoding

### DIFF
--- a/Codec/Archive/Zip/Conduit/Encoding.hs
+++ b/Codec/Archive/Zip/Conduit/Encoding.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Codec.Archive.Zip.Conduit.Encoding
+  ( encodeZipEntryName
+  , decodeZipEntryName
+  , encodeZipEntry
+  ) where
+
+import Codec.Archive.Zip.Conduit.Types (ZipEntry(..))
+import Data.Encoding ( decodeStrictByteStringExplicit
+                     , encodeStrictByteStringExplicit
+                     )
+import Data.Encoding.CP437
+import Data.Encoding.UTF8
+
+import Data.Time (LocalTime)
+import Data.Word (Word64)
+
+import Data.Maybe
+import Data.Monoid
+import Data.Foldable (asum)
+import Control.Monad
+import Control.Monad.Catch (MonadThrow(..))
+import Control.Monad.Trans.Except
+
+import Data.ByteString (ByteString)
+
+
+decodeZipEntryName :: MonadThrow m => ZipEntry -> m FilePath
+-- ^ Extract the filename from a 'ZipEntry' doing decoding along the way.
+--
+-- Throws 'Data.Encoding.Exception.DecodingException's.
+decodeZipEntryName ZipEntry{..}
+  | zipEntryNameIsUTF8 = either throwM return $ decodeStrictByteStringExplicit UTF8 zipEntryName
+  | otherwise          = either throwM return $ decodeStrictByteStringExplicit CP437 zipEntryName
+  
+encodeZipEntryName :: MonadThrow m => FilePath -> m (Bool, ByteString)
+-- ^ Encode a filename for use in a 'ZipEntry', returns a 'Bool' indicating
+--   whether the result had to be encoded as 'UTF8' rather than the standard
+--   'CP437'.
+--
+-- Does not do any normalisation (in particular this function does not ensure
+-- that the 'FilePath' does not start with a slash).
+--
+-- Throws 'Data.Encoding.Exception.EncodingException's if the 'FilePath' cannot
+-- be encoded as 'UTF8' (which we assume to be a strict superset of 'CP437').
+encodeZipEntryName path = either (throwM . fromJust . getLast) return <=< runExceptT $ asum
+  [ fmap (False, ) . either (throwE . Last . Just) return $ encodeStrictByteStringExplicit CP437 path
+  , fmap (True, ) . either (throwE . Last . Just) return $ encodeStrictByteStringExplicit UTF8 path
+  ]
+
+encodeZipEntry :: MonadThrow m
+               => FilePath -- ^ 'zipEntryName'
+               -> LocalTime -- ^ 'zipEntryTime'
+               -> Maybe Word64 -- ^ 'zipEntrySize'
+               -> m ZipEntry
+-- ^ Smart constructor for 'ZipEntry' which calls 'encodeZipEntryName'.
+encodeZipEntry path zipEntryTime zipEntrySize = do
+  (zipEntryNameIsUTF8, zipEntryName) <- encodeZipEntryName path
+  return ZipEntry{..}

--- a/Codec/Archive/Zip/Conduit/Types.hs
+++ b/Codec/Archive/Zip/Conduit/Types.hs
@@ -9,6 +9,7 @@ import           Data.String (IsString(..))
 import           Data.Time.LocalTime (LocalTime)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
+import           System.FilePath (FilePath)
 
 -- |Errors thrown during zip file processing
 newtype ZipError = ZipError String
@@ -28,7 +29,7 @@ data ZipInfo = ZipInfo
 -- |(The beginning of) a single entry in a zip stream, which may be any file or directory.
 -- As per zip file conventions, directory names should end with a slash and have no data, but this library does not ensure that.
 data ZipEntry = ZipEntry
-  { zipEntryName :: ByteString -- ^File name (in posix format, no leading slashes), usually utf-8 encoded, with a trailing slash for directories
+  { zipEntryName :: FilePath -- ^File name (in posix format, no leading slashes) with a trailing slash for directories
   , zipEntryTime :: LocalTime -- ^Modification time
   , zipEntrySize :: Maybe Word64 -- ^Size of file data (if known); checked on zipping and also used as hint to enable zip64
   } deriving (Eq, Show)

--- a/Codec/Archive/Zip/Conduit/Types.hs
+++ b/Codec/Archive/Zip/Conduit/Types.hs
@@ -9,7 +9,6 @@ import           Data.String (IsString(..))
 import           Data.Time.LocalTime (LocalTime)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
-import           System.FilePath (FilePath)
 
 -- |Errors thrown during zip file processing
 newtype ZipError = ZipError String
@@ -29,9 +28,10 @@ data ZipInfo = ZipInfo
 -- |(The beginning of) a single entry in a zip stream, which may be any file or directory.
 -- As per zip file conventions, directory names should end with a slash and have no data, but this library does not ensure that.
 data ZipEntry = ZipEntry
-  { zipEntryName :: FilePath -- ^File name (in posix format, no leading slashes) with a trailing slash for directories
-  , zipEntryTime :: LocalTime -- ^Modification time
-  , zipEntrySize :: Maybe Word64 -- ^Size of file data (if known); checked on zipping and also used as hint to enable zip64
+  { zipEntryName       :: ByteString -- ^File name (in posix format, no leading slashes), with a trailing slash for directories
+  , zipEntryNameIsUTF8 :: Bool -- ^True if 'zipEntryName' is encoded as UTF-8
+  , zipEntryTime       :: LocalTime -- ^Modification time
+  , zipEntrySize       :: Maybe Word64 -- ^Size of file data (if known); checked on zipping and also used as hint to enable zip64
   } deriving (Eq, Show)
 
 -- |The data contents for a 'ZipEntry'. For empty entries (e.g., directories), use 'mempty'.

--- a/Codec/Archive/Zip/Conduit/UnZip.hs
+++ b/Codec/Archive/Zip/Conduit/UnZip.hs
@@ -98,7 +98,7 @@ fromDOSTime time date = LocalTime
 -- This only supports a limited number of zip file features, including deflate compression and zip64.
 -- It does not (ironically) support uncompressed zip files that have been created as streams, where file sizes are not known beforehand.
 -- Since it does not use the offset information at the end of the file, it assumes all entries are packed sequentially, which is usually the case.
--- Any errors are thrown in the underlying monad (as 'ZipError's or 'Data.Conduit.Serialization.Binary.ParseError').
+-- Any errors are thrown in the underlying monad (as 'ZipError's, 'Data.Conduit.Serialization.Binary.ParseError's, or 'Data.Encoding.DecodingException's).
 unZipStream :: (MonadBase b m, PrimMonad b, MonadThrow m) => C.ConduitM BS.ByteString (Either ZipEntry BS.ByteString) m ZipInfo
 unZipStream = next where
   next = do -- local header, or start central directory

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -92,7 +92,7 @@ maxBound16 = fromIntegral (maxBound :: Word16)
 -- The final result is the total size of the zip file.
 --
 -- Depending on options, the resulting zip file should be compatible with most unzipping applications.
--- Any errors are thrown in the underlying monad (as 'ZipError's).
+-- Any errors are thrown in the underlying monad (as 'ZipError's or 'Data.Encoding.EncodingException's).
 zipStream :: (MonadBase b m, PrimMonad b, MonadThrow m) => ZipOptions -> C.ConduitM (ZipEntry, ZipData m) BS.ByteString m Word64
 zipStream ZipOptions{..} = execStateC 0 $ do
   (cnt, cdir) <- next 0 (return ())

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -15,14 +15,13 @@ import qualified Codec.Compression.Zlib.Raw as Z
 import           Control.Arrow ((&&&), (+++), left)
 import           Control.Monad (when)
 import           Control.Monad.Base (MonadBase)
-import           Control.Monad.Catch (MonadThrow)
+import           Control.Monad.Catch (MonadThrow(..))
 import           Control.Monad.Primitive (PrimMonad)
 import           Control.Monad.State.Strict (StateT, get)
 import           Control.Monad.Trans.Resource (MonadResource)
 import qualified Data.Binary.Put as P
 import           Data.Bits (bit, shiftL, shiftR, (.|.))
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Binary as CB
@@ -34,6 +33,8 @@ import           Data.Either (isLeft)
 import           Data.Maybe (fromMaybe, fromJust)
 import           Data.Time (LocalTime(..), TimeOfDay(..), toGregorian)
 import           Data.Word (Word16, Word64)
+import           Data.Encoding (encodeStrictByteStringExplicit)
+import           Data.Encoding.UTF8
 
 import           Codec.Archive.Zip.Conduit.Types
 import           Codec.Archive.Zip.Conduit.Internal
@@ -102,10 +103,11 @@ zipStream ZipOptions{..} = execStateC 0 $ do
   where
   next cnt dir = C.await >>= maybe
     (return (cnt, dir))
-    (\e -> do
-      d <- entry e
-      next (succ cnt) $ dir >> d)
-  entry (ZipEntry{..}, zipData -> dat) = do
+    (\(e, d) -> do
+        n <- either throwM return $ encodeStrictByteStringExplicit UTF8 (zipEntryName e)
+        d <- entry (e, n, d)
+        next (succ cnt) $ dir >> d)
+  entry (ZipEntry{..}, name, zipData -> dat) = do
     let usiz = dataSize dat
         sdat = left ((C..| sizeCRC) . C.toProducer) dat
         comp = zipOptCompressLevel /= 0 && all (0 /=) usiz
@@ -117,12 +119,12 @@ zipStream ZipOptions{..} = execStateC 0 $ do
           | otherwise = (left (fmap (id &&& fst)) sdat, usiz)
         z64 = maybe (zipOpt64 || any (maxBound32 <) zipEntrySize)
           (maxBound32 <) (max <$> usiz <*> csiz)
-        namelen = BS.length zipEntryName
+        namelen = BS.length name
         (time, date) = toDOSTime zipEntryTime
         mcrc = either (const Nothing) (Just . crc32) dat
-    when (namelen > maxBound16) $ zipError $ BSC.unpack zipEntryName ++ ": entry name too long"
+    when (namelen > maxBound16) $ zipError $ zipEntryName ++ ": entry name too long"
     let common = do
-          P.putWord16le $ isLeft dat ?* bit 3
+          P.putWord16le $ bit 11 .|. isLeft dat ?* bit 3
           P.putWord16le $ comp ?* 8
           P.putWord16le $ time
           P.putWord16le $ date
@@ -136,7 +138,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
       P.putWord32le $ if z64 then maxBound32 else maybe 0 fromIntegral usiz
       P.putWord16le $ fromIntegral namelen
       P.putWord16le $ z64 ?* 20
-      P.putByteString zipEntryName
+      P.putByteString name
       when z64 $ do
         P.putWord16le 0x0001
         P.putWord16le 16
@@ -146,7 +148,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
     ((usz, crc), csz) <- either
       (\cd -> do
         r@((usz, crc), csz) <- outsz cd -- write compressed data
-        when (not z64 && (usz > maxBound32 || csz > maxBound32)) $ zipError $ BSC.unpack zipEntryName ++ ": file too large and zipOpt64 disabled"
+        when (not z64 && (usz > maxBound32 || csz > maxBound32)) $ zipError $ zipEntryName ++ ": file too large and zipOpt64 disabled"
         output $ do
           P.putWord32le 0x08074b50
           P.putWord32le crc
@@ -158,7 +160,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
         return r)
       (\b -> outsz $ ((fromJust usiz, fromJust mcrc), fromJust csiz) <$ CB.sourceLbs b)
       cdat
-    when (any (usz /=) zipEntrySize) $ zipError $ BSC.unpack zipEntryName ++ ": incorrect zipEntrySize"
+    when (any (usz /=) zipEntrySize) $ zipError $ zipEntryName ++ ": incorrect zipEntrySize"
     return $ do
       -- central directory
       let o64 = off >= maxBound32
@@ -178,7 +180,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
       P.putWord16le 0 -- internal file attributes
       P.putWord32le 0 -- external file attributes
       P.putWord32le $ if o64 then maxBound32 else fromIntegral off
-      P.putByteString zipEntryName
+      P.putByteString name
       when a64 $ do
         P.putWord16le 0x0001
         P.putWord16le l64

--- a/cmd/unzip.hs
+++ b/cmd/unzip.hs
@@ -22,9 +22,9 @@ import           Codec.Archive.Zip.Conduit.UnZip
 extract :: C.Sink (Either ZipEntry BS.ByteString) IO ()
 extract = C.awaitForever start where
   start (Left ZipEntry{..}) = do
-    liftIO $ BSC.putStrLn zipEntryName
+    liftIO $ putStrLn zipEntryName
     liftIO $ createDirectoryIfMissing True (takeDirectory name)
-    if BSC.last zipEntryName == '/'
+    if last zipEntryName == '/'
       then when ((0 /=) `any` zipEntrySize) $ fail $ name ++ ": non-empty directory"
       else do -- C.bracketP
         h <- liftIO $ openFile name WriteMode
@@ -34,7 +34,7 @@ extract = C.awaitForever start where
 #if MIN_VERSION_directory(1,2,3)
     liftIO $ setModificationTime name $ localTimeToUTC utc zipEntryTime -- FIXME: timezone
 #endif
-    where name = BSC.unpack $ BSC.dropWhile ('/' ==) zipEntryName -- should we utf8 decode?
+    where name = dropWhile ('/' ==) zipEntryName -- should we utf8 decode?
   start (Right _) = fail "Unexpected leading or directory data contents"
   write = C.await >>= maybe
     (return ())

--- a/cmd/zip.hs
+++ b/cmd/zip.hs
@@ -38,7 +38,7 @@ generate :: (MonadIO m, MonadResource m) => [FilePath] -> C.Source m (ZipEntry, 
 generate (p:paths) = do
   t <- liftIO $ getModificationTime p
   let e = ZipEntry
-        { zipEntryName = BSC.pack $ dropWhile ('/' ==) p
+        { zipEntryName = dropWhile ('/' ==) p
         , zipEntryTime = utcToLocalTime utc t -- FIXME: timezone
         , zipEntrySize = Nothing
         }
@@ -50,7 +50,7 @@ generate (p:paths) = do
 #else
       dl <- liftIO $ filter (`notElem` [".",".."]) . map (p </>) <$> getDirectoryContents p
 #endif
-      C.yield (e{ zipEntryName = zipEntryName e `BSC.snoc` '/', zipEntrySize = Just 0 }, mempty)
+      C.yield (e{ zipEntryName = zipEntryName e ++ "/", zipEntrySize = Just 0 }, mempty)
       generate $ dl ++ paths
     else do
       C.yield (e, zipFileData p)

--- a/cmd/zip.hs
+++ b/cmd/zip.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 import           Control.Monad (filterM, void)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Control.Monad.Trans.Resource (MonadResource, runResourceT)
+import           Control.Monad.Trans.Resource (MonadResource, runResourceT, MonadThrow)
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Binary as CB
@@ -21,6 +21,7 @@ import           System.FilePath.Posix ((</>)) -- zip files only want forward sl
 import           System.IO (stdout, hPutStrLn, stderr)
 
 import           Codec.Archive.Zip.Conduit.Zip
+import           Codec.Archive.Zip.Conduit.Encoding
 
 opts :: [Opt.OptDescr (ZipOptions -> ZipOptions)]
 opts =
@@ -34,14 +35,11 @@ opts =
     "set zip comment"
   ]
 
-generate :: (MonadIO m, MonadResource m) => [FilePath] -> C.Source m (ZipEntry, ZipData m)
+generate :: (MonadIO m, MonadResource m, MonadThrow m) => [FilePath] -> C.Source m (ZipEntry, ZipData m)
 generate (p:paths) = do
   t <- liftIO $ getModificationTime p
-  let e = ZipEntry
-        { zipEntryName = dropWhile ('/' ==) p
-        , zipEntryTime = utcToLocalTime utc t -- FIXME: timezone
-        , zipEntrySize = Nothing
-        }
+  -- FIXME: timezone
+  e <- encodeZipEntry (dropWhile ('/' ==) p) (utcToLocalTime utc t) Nothing
   isd <- liftIO $ doesDirectoryExist p
   if isd
     then do
@@ -50,7 +48,7 @@ generate (p:paths) = do
 #else
       dl <- liftIO $ filter (`notElem` [".",".."]) . map (p </>) <$> getDirectoryContents p
 #endif
-      C.yield (e{ zipEntryName = zipEntryName e ++ "/", zipEntrySize = Just 0 }, mempty)
+      C.yield (e{ zipEntryName = zipEntryName e `BSC.snoc` '/', zipEntrySize = Just 0 }, mempty)
       generate $ dl ++ paths
     else do
       C.yield (e, zipFileData p)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
 resolver: lts-8.13
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+  - encoding-0.8.2
+  - regex-compat-0.93.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-9.9
 packages:
-- '.'
+  - '.'
 extra-deps:
-  - encoding-0.8.2
   - regex-compat-0.93.1
+  - encoding-0.8.2

--- a/zip-stream.cabal
+++ b/zip-stream.cabal
@@ -38,7 +38,9 @@ library
     resourcet,
     time,
     transformers-base,
-    zlib
+    zlib,
+    encoding,
+    filepath
 
 executable unzip-stream
   main-is: unzip.hs

--- a/zip-stream.cabal
+++ b/zip-stream.cabal
@@ -18,6 +18,7 @@ source-repository head
 library
   exposed-modules:     
     Codec.Archive.Zip.Conduit.Types
+    Codec.Archive.Zip.Conduit.Encoding
     Codec.Archive.Zip.Conduit.UnZip
     Codec.Archive.Zip.Conduit.Zip
   other-modules:
@@ -40,8 +41,8 @@ library
     transformers-base,
     zlib,
     encoding,
-    filepath
-
+    transformers
+        
 executable unzip-stream
   main-is: unzip.hs
   hs-source-dirs: cmd


### PR DESCRIPTION
The documentation says about filenames "usually UTF-8 encoded".

ZIP actually has a flag to indicate that filenames are to be considered as UTF8-encoded.
If the flag is not set filenames are, by specification, encoded as CP437 (I´m aware that this is not the case in practice but since there is no way to actually indicate any other encoding this would at least break _less_ things than also assuming UTF8 in this case)