### PR TITLE
Don't set compression flag for known 0-byte files

### DIFF
--- a/Codec/Archive/Zip/Conduit/Types.hs
+++ b/Codec/Archive/Zip/Conduit/Types.hs
@@ -32,7 +32,7 @@ data ZipInfo = ZipInfo
 data ZipEntry = ZipEntry
   { zipEntryName :: Either T.Text ByteString -- ^File name (in posix format, no leading slashes), either UTF-8 encoded text or raw bytes (CP437), with a trailing slash for directories
   , zipEntryTime :: LocalTime -- ^Modification time
-  , zipEntrySize :: Maybe Word64 -- ^Size of file data (if known); checked on zipping and also used as hint to enable zip64
+  , zipEntrySize :: Maybe Word64 -- ^Size of file data (if known); checked on zipping and also used as hint to enable zip64. Disables compression for known 0-byte files.
   , zipEntryExternalAttributes :: Maybe Word32 -- ^Host-dependent attributes, often MS-DOS directory attribute byte (only supported when zipping)
   } deriving (Eq, Show)
 

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -120,7 +120,9 @@ zipStream ZipOptions{..} = execStateC 0 $ do
   entry (ZipEntry{..}, zipData -> dat) = do
     let usiz = dataSize dat
         sdat = left ((C..| sizeCRC) . C.toProducer) dat
-        comp = zipOptCompressLevel /= 0 && all (0 /=) usiz
+        comp = zipOptCompressLevel /= 0
+               && all (0 /=) usiz
+               && all (0 /=) zipEntrySize
         (cdat, csiz)
           | comp =
             ( ((`C.fuseBoth` (outputSize $ CZ.compress zipOptCompressLevel deflateWindowBits))

--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -77,7 +77,7 @@ dataSize (Left _) = Nothing
 dataSize (Right b) = Just $ fromIntegral $ BSL.length b
 
 toDOSTime :: LocalTime -> (Word16, Word16)
-toDOSTime (LocalTime (toGregorian -> (year, month, day)) (TimeOfDay hour mins secs)) = 
+toDOSTime (LocalTime (toGregorian -> (year, month, day)) (TimeOfDay hour mins secs)) =
   ( fromIntegral hour `shiftL` 11 .|. fromIntegral mins `shiftL` 5 .|. truncate secs `shiftR` 1
   , fromIntegral (year - 1980) `shiftL` 9 .|. fromIntegral month `shiftL` 5 .|. fromIntegral day
   )
@@ -97,7 +97,7 @@ maxBound16 = fromIntegral (maxBound :: Word16)
 --
 -- Depending on options, the resulting zip file should be compatible with most unzipping applications.
 -- Any errors are thrown in the underlying monad (as 'ZipError's).
-zipStream :: 
+zipStream ::
   ( MonadThrow m
 #if MIN_VERSION_conduit(1,3,0)
   , PrimMonad m
@@ -110,7 +110,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
   cdoff <- get
   output cdir
   eoff <- get
-  endDirectory cdoff (eoff - cdoff) cnt 
+  endDirectory cdoff (eoff - cdoff) cnt
   where
   next cnt dir = C.await >>= maybe
     (return (cnt, dir))

--- a/cmd/unzip.hs
+++ b/cmd/unzip.hs
@@ -52,7 +52,7 @@ main = do
   unless (null args) $ do
     hPutStrLn stderr $ "Usage: " ++ prog ++ "\nRead a zip file from stdin and extract it in the current directory."
     exitFailure
-  ZipInfo{..} <- C.runConduit 
+  ZipInfo{..} <- C.runConduit
     $ CB.sourceHandle stdin
     C..| C.fuseUpstream unZipStream extract
   BSC.putStrLn zipComment


### PR DESCRIPTION
The compression flag was already unset for 0-byte _ByteStrings_, however, for empty files it would still be set even when a size was explicitly set in the ZipEntry. This patch fixes that. 

It should actually be possible to determine whether a Conduit stream is empty by demanding the first (non-empty) fragment and creating a new conduit that first yields the retrieved fragment and then continues with the old conduit as usual.  This should not impact the memory usage as the fragment would be fetched immediately after anyway. I have not tried to implement that yet, though.