### PR TITLE
support GHC 9.0

### DIFF
--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -119,7 +119,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
       next (succ cnt) $ dir >> d)
   entry (ZipEntry{..}, zipData -> dat) = do
     let usiz = dataSize dat
-        sdat = left ((C..| sizeCRC) . C.toProducer) dat
+        sdat = left (\x -> C.toProducer x C..| sizeCRC) dat
         comp = zipOptCompressLevel /= 0
                && all (0 /=) usiz
                && all (0 /=) zipEntrySize


### PR DESCRIPTION
On GHC 9.0.1, current `master` fails with this error message:

<details>
<summary>
Click to show
</summary>

```
Codec/Archive/Zip/Conduit/Zip.hs:122:39: error:
    • Couldn't match type: forall i1.
                           C.ConduitT i1 BSC.ByteString m1 ()
                     with: C.ConduitT a BSC.ByteString m3 ()
      Expected: C.Source m1 BSC.ByteString
                -> C.ConduitM a BSC.ByteString m3 ()
        Actual: C.Source m1 BSC.ByteString
                -> C.Producer m1 BSC.ByteString
    • In the second argument of ‘(.)’, namely ‘C.toProducer’
      In the first argument of ‘left’, namely
        ‘((C..| sizeCRC) . C.toProducer)’
      In the expression: left ((C..| sizeCRC) . C.toProducer) dat
    • Relevant bindings include
        sdat :: Either
                  (C.ConduitM a BSC.ByteString m3 (Word64, GHC.Word.Word32))
                  BSL.ByteString
          (bound at Codec/Archive/Zip/Conduit/Zip.hs:122:9)
        dat :: Either (C.ConduitM () BSC.ByteString m1 ()) BSL.ByteString
          (bound at Codec/Archive/Zip/Conduit/Zip.hs:120:35)
        entry :: (ZipEntry, ZipData m1)
                 -> C.ConduitT i BSC.ByteString (StateT Word64 m2) (P.PutM ())
          (bound at Codec/Archive/Zip/Conduit/Zip.hs:120:3)
    |
122 |         sdat = left ((C..| sizeCRC) . C.toProducer) dat
    |
```

</details>

This is expected and due to [simplified subsumption](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption), the solution is to eta-expand the code.

Tested locally with
```
cabal build -w ghc-9.0
```