### PR TITLE
Fix constant-memory compression not working for `ZipDataByteString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## _unreleased_
+
+* Fix constant-memory streaming not working for `ZipDataByteString`.
+* Fix `ZipDataByteString` not respecting compression level.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Control.Monad (when, void)
+import           Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Conduit as C
+import           Data.Conduit.Combinators (sinkNull)
+import           Data.Foldable (for_)
+import qualified Data.Text as T
+import           Data.Time.LocalTime (utc, utcToLocalTime)
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import           GHC.Stats (getRTSStats, RTSStats(..), GCDetails(..))
+import           System.Mem (performMajorGC)
+import           Test.Hspec (hspec, describe, it)
+
+import           Codec.Archive.Zip.Conduit.Zip
+
+
+main :: IO ()
+main = hspec $ do
+  describe "zipping" $ do
+    it "ZipDataByteString streams in constant memory" $ do
+      C.runConduitRes $
+        (do
+          -- Stream 1000 * 4 MiB = 4 GiB
+          for_ [(1::Int)..1024] $ \i -> do
+            -- `bs` needs to depend on loop variable `i`, otherwise GHC may hoist
+            -- it out of the loop ("floating"), making the memory constant
+            -- even for incorrect implementations, thus making the test useless.
+            let !bs = BS.replicate (4 * 1024 * 1024) (fromIntegral i) -- 4 MiB
+
+            C.yield
+              ( ZipEntry
+                  { zipEntryName = Left ("file-" <> T.pack (show i) <> ".bin")
+                  , zipEntryTime = utcToLocalTime utc (posixSecondsToUTCTime 0)
+                  , zipEntrySize = Nothing
+                  , zipEntryExternalAttributes = Nothing
+                  }
+              , ZipDataByteString (BSL.fromStrict bs) -- `copy` to avoid sharing
+              )
+
+            liftIO $ do
+              -- GC every 40 MB to make it easy to observe constant memory.
+              when (i `mod` 10 == 0) performMajorGC
+
+              RTSStats{ gc = GCDetails{ gcdetails_live_bytes } } <- getRTSStats
+              when (gcdetails_live_bytes > 3 * 1024 * 1024 * 1024) $ do -- 3 GiB
+                error $ "Memory usage too high (" ++ show gcdetails_live_bytes ++ " B), probably streaming is not constant-memory"
+
+        )
+        C..| void (zipStream defaultZipOptions{ zipOptCompressLevel = 0 })
+        C..| sinkNull
+        :: IO ()
+

--- a/zip-stream.cabal
+++ b/zip-stream.cabal
@@ -31,6 +31,7 @@ library
     bytestring,
     conduit >= 1.3,
     conduit-extra,
+    deepseq,
     digest,
     exceptions,
     mtl,

--- a/zip-stream.cabal
+++ b/zip-stream.cabal
@@ -75,3 +75,19 @@ executable zip-stream
     time,
     transformers,
     zip-stream
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  default-language: Haskell2010
+  main-is: Main.hs
+  -- `-T` is needed for https://hackage.haskell.org/package/base-4.17.0.0/docs/GHC-Stats.html
+  ghc-options: -Wall -threaded -with-rtsopts=-T
+  build-depends:
+      base
+    , zip-stream
+    , bytestring
+    , conduit
+    , hspec
+    , text
+    , time


### PR DESCRIPTION
Thanks for this library, it is very useful. Here comes a contribution :)

[The docs say](https://hackage.haskell.org/package/zip-stream-0.2.1.0/docs/Codec-Archive-Zip-Conduit-Zip.html):

> file data is never kept in memory (beyond a single [ZipDataByteString](https://hackage.haskell.org/package/zip-stream-0.2.1.0/docs/Codec-Archive-Zip-Conduit-Zip.html#v:ZipDataByteString))

This is false so far.

All `ZipDataByteString` are kept in memory until the ZIP is finished, thus OOMing servers that try to stream large ZIP archives.

The reason for this are various space leaks in:

* The `State` monad used to track the number of written bytes; [`Control.Monad.Trans.Strict`](https://www.stackage.org/haddock/lts-19.30/transformers-0.5.6.2/Control-Monad-Trans-State-Strict.html) docs say:
  > In this version, sequencing of computations is strict (but computations are **not strict in the state unless you force** it with `seq` or the like).
  The library did not honour that, e.g. in `let outsz c = stateC $ \o -> ...`, state was modified lazily.
* The size variable `csz`.
* The `P.putWord16le` call capturing a reference to the ByteString in `dat`.

The package so far has no test suite to ensure that the "file data is never kept in memory" claim is actually true, so I added one.
(More tests should be added e.g. to property-test round-trip encoding.)

My commit `Fix constant-memory streaming not working for ZipDataByteString` fixes the issues above with the minimal possible changes.

For easiest review, please see the individual commits.

---

However, I don't think the library should keep it at that.

The correctness of a constant-memory-streaming library should not depend on some sparsely and arcanely placed `!` symbols. Instead, I think that:

* The code should be further improved to make super clear which variables are captured in the function that is returned to write the central directory in a deferred way  (`return $ do ...`), so that they can be easily strictified, versus being able to capture everything from the surrounding code -- that easily leads to bugs like this. Instead of passing functions, pass plain data types with strict fields (e.g. `StrictData`) whose memory usage and lifetime can be reasoned about.

Concretely:

Capture all variables from this block https://github.com/dylex/zip-stream/blob/735fe015a4a19b4c93b096a8761efb206b6b89f4/Codec/Archive/Zip/Conduit/Zip.hs#L171-L200

in data types such as

```haskell
{-# LANGUAGE StrictData #-}
-- ...

data CommonFileHeaderInfo = CommonFileHeaderInfo
  { cfhi_isStreamingEntry :: Bool
  , cfhi_hasUtf8Filename :: Bool
  , cfhi_isCompressed :: Bool
  , cfhi_time :: Word16
  , cfhi_date :: Word16
  } deriving (Eq, Ord, Show)

data CentralDirectoryInfo = CentralDirectoryInfo
  { cdi_off :: Word64
  , cdi_z64 :: Bool
  , cdi_commonFileHeaderInfo :: CommonFileHeaderInfo
  , cdi_crc :: Word32
  , cdi_usz :: Word64
  , cdi_name :: BSC.ByteString
  , cdi_csz :: Word64
  , cdi_zipEntryExternalAttributes :: Maybe Word32 -- lazy Maybe must be e.g. via `force` at creation
  } deriving (Eq, Ord, Show)

putCommonFileHeaderPart :: CommonFileHeaderInfo -> P.PutM ()
-- ...
putCentralDirectory :: CentralDirectoryInfo -> P.PutM ()
-- ...
```

and replace the block mentioned by:

```haskell
    let !centralDirectoryInfo = CentralDirectoryInfo
          { cdi_off = off
          , cdi_z64 = z64
          , cdi_commonFileHeaderInfo = commonFileHeaderInfo
          , cdi_crc = crc
          , cdi_usz = usz
          , cdi_name = name
          , cdi_csz = csz
          , cdi_zipEntryExternalAttributes = force zipEntryExternalAttributes
          }
    return $ putCentralDirectory centralDirectoryInfo
```

This guarantees absence of thunk-related space leaks.

I have included this fix as the commit `zipStream: Ensure absence of space leaks via defunctionalisation`.

This refactoring has another benefit: We can now conclude very easily how many bytes are retained per entry until the end of the archive, simply by inspecting the fields of `CentralDirectoryInfo`.
You already wrote in the [docs](https://hackage.haskell.org/package/zip-stream-0.2.1.0/docs/Codec-Archive-Zip-Conduit-Zip.html)

> consuming an additional ~100 bytes of state per entry during streaming

and now we can easily reason about whether that's really true.
It also makes it easier to optimise this storage, e.g. the various `Bool`s and `Word16/32`s are all stored as 64-bit values by GHC, and they could be bit-packed for additional memory savings.

Cheers!
Niklas