### PR TITLE
Fix skipping over FileHeader Ext in unZipStream

### DIFF
--- a/Codec/Archive/Zip/Conduit/UnZip.hs
+++ b/Codec/Archive/Zip/Conduit/UnZip.hs
@@ -182,6 +182,7 @@ unZipStream = next where
               -- the zip specs claim "the Local header MUST include BOTH" but "only if the corresponding field is set to 0xFFFFFFFF"
               usiz' <- if usiz == maxBound32 then G.getWord64le else return $ extZip64USize ext
               csiz' <- if csiz == maxBound32 then G.getWord64le else return $ extZip64CSize ext
+              G.skip z
               return ext
                 { extZip64 = True
                 , extZip64USize = usiz'


### PR DESCRIPTION
Hi @dylex , thanks for the library!

I'll be up-front: I've no idea what I'm doing in this patch. I haven't read the spec (-s?), am floaty on the format — I was just testing a thing, and literally on 2nd input got the error:

> unzip-stream: ParseError {unconsumed = "......", offset = 59, content = "isolate: the decoder consumed 0 bytes which is less than the expected 16 bytes"}

Applying this "shoot in the dark" patch on top of master — fixes it.

All I did was poke the `traceM`'s, and a few glances at the input file's hexdump.

In a very narrow local sense, seems sensible to skip here: `G.isolate n` asserts exactly `n` bytes will be consumed; and these 20 "ext" bytes in my case look not too useful, `t` `01 00`, `z` `10 00`, and two LE int64's `88 2d 00 00 00 00 00 00`, `c8 0c 00 00 00 00 00 00`: 

```
00000000  50 4b 03 04 0a 00 00 08  00 00 4d 75 ec 58 00 00  |PK........Mu.X..|
00000010  00 00 00 00 00 00 00 00  00 00 05 00 00 00 65 6e  |..............en|
00000020  75 73 2f 50 4b 03 04 0a  00 00 08 08 00 da 74 ec  |us/PK.........t.|
00000040  00 65 6e 75 73 2f 43 68  75 6e 6b 31 36 35 34 33  |.enus/Chunk16543|
00000050  37 35 31 37 39 2e 68 74  6d 6c 01 00 10 00 88 2d  |75179.html.....-|
00000060  00 00 00 00 00 00 c8 0c  00 00 00 00 00 00 d5 5a  |...............Z|
00000070 <deflate stream of 1st file>
```

Then again, I've no clue if this makes any sense in general. Not even sure how to call this "ext" properly.
But — seems to work fine! `¯\_(ツ)_/¯`

Please review.

I'd love to get a fix landed, so that unzipping is also (more) reliable. Been using the compression half of the lib, getting great mileage out of it past year+, pretty content with it if not to say happy.