### PR TITLE
[BUG] `ZipDataSource mempty` compresses to invalid zip files; add test

### DIFF
--- a/Codec/Archive/Zip/Conduit/Zip.hs
+++ b/Codec/Archive/Zip/Conduit/Zip.hs
@@ -221,6 +221,7 @@ zipStream ZipOptions{..} = execStateC 0 $ do
         P.putWord64le $ fromMaybe 0 usiz
         P.putWord64le $ fromMaybe 0 csiz
     let outsz c = stateC $ \(!o) -> (id &&& (o +) . snd) <$> c
+    -- let outsz c = stateC $ \(!o) -> (id &&& (o +) . snd) <$> (C.yield mempty >> c)
     ((cdiUsz, cdiCrc), cdiCsz) <- either
       (\cd -> do
         r@((usz, crc), csz) <- outsz cd -- write compressed data

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Main (main) where
 
@@ -8,17 +9,20 @@ import           Control.Monad (when, void)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import           Data.Conduit ((.|))
 import qualified Data.Conduit as C
-import           Data.Conduit.Combinators (sinkNull)
+import qualified Data.Conduit.Binary as C (sinkLbs, sourceLbs)
+import           Data.Conduit.Combinators as C -- (sinkFile, sinkNull)
 import           Data.Foldable (for_)
 import qualified Data.Text as T
 import           Data.Time.LocalTime (utc, utcToLocalTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           GHC.Stats (getRTSStats, RTSStats(..), GCDetails(..))
 import           System.Mem (performMajorGC)
-import           Test.Hspec (hspec, describe, it)
+import           Test.Hspec (describe, hspec, it, shouldBe)
 
 import           Codec.Archive.Zip.Conduit.Zip
+import           Codec.Archive.Zip.Conduit.UnZip
 
 
 main :: IO ()
@@ -56,4 +60,43 @@ main = hspec $ do
         C..| void (zipStream defaultZipOptions{ zipOptCompressLevel = 0 })
         C..| sinkNull
         :: IO ()
+
+    it "ZipDataSource behaves correctly with empty conduits" $ do
+      zipbytes <- C.runConduitRes
+                $ entries
+               .| void (zipStream defaultZipOptions)
+               .| C.sinkLbs
+      C.runConduitRes $ C.sourceLbs zipbytes .| C.sinkFile "/tmp/test.zip"
+      ZipInfo{..} <- C.runConduitRes
+                   $ C.sourceLbs zipbytes
+                  .| C.fuseUpstream unZipStream (C.awaitForever assertItem)
+      zipComment `shouldBe` ""
+    where
+      entries = do
+        C.yield ( simpleZipEntry "roses.txt"
+                , ZipDataSource (C.yield "Roses are red\n")
+                )
+        C.yield (simpleZipEntry "empty_OK_1.txt", ZipDataByteString "")
+        C.yield (simpleZipEntry "empty_OK_2.txt", ZipDataSource emptySingleChunk)
+        C.yield (simpleZipEntry "empty_BUG.txt", ZipDataSource emptyNoYield)
+        C.yield (simpleZipEntry "trailer.txt", ZipDataByteString "FIN")
+
+      emptySingleChunk = C.yield ""
+      emptyNoYield = mempty -- return ()
+
+      posixEpoch = utcToLocalTime utc (posixSecondsToUTCTime 0)
+      simpleZipEntry fname = ZipEntry{..} where
+        zipEntryName = Left fname
+        zipEntryTime = posixEpoch
+        zipEntrySize = Nothing
+        zipEntryExternalAttributes = Nothing
+
+      assertItem (Right _) = fail "Unexpected leading or directory data contents"
+      assertItem (Left ZipEntry{..}) = liftIO $ do
+        zipEntryTime `shouldBe` posixEpoch
+        when (zipEntryName == Left "roses.txt") $ zipEntrySize `shouldBe` Just 14
+        when (zipEntryName == Left "empty_OK_1.txt") $ zipEntrySize `shouldBe` Just 0
+        when (zipEntryName == Left "empty_OK_2.txt") $ zipEntrySize `shouldBe` Just 0
+        when (zipEntryName == Left "empty_BUG.txt") $ zipEntrySize `shouldBe` Just 0
+        when (zipEntryName == Left "trailer.txt") $ zipEntrySize `shouldBe` Just 3
 

--- a/zip-stream.cabal
+++ b/zip-stream.cabal
@@ -89,6 +89,7 @@ test-suite tests
     , zip-stream
     , bytestring
     , conduit
+    , conduit-extra
     , hspec
     , text
     , time


### PR DESCRIPTION
Hi again @dylex!

When using the compression part of the library in production, we stumbled over a corner-case. Turns out, if archive member data is provided through a conduit (via `ZipDataSource`), and that conduit **never yields** — the output zip archive is... I don't want to say "corrupted" (ubuntu's `unzip` still partially extracts it — but not all decompressors do, including the one in this library) — let's say, definitely "not entirely valid".

Please try the added test. It fails unexpectedly, and you can check the produced output. Infozip's `unzip` says `invalid compressed data to inflate` on it:

```
$ unzip /tmp/test.zip
Archive:  /tmp/test.zip
  inflating: roses.txt               
 extracting: empty_OK_1.txt          
  inflating: empty_OK_2.txt          
  inflating: empty_BUG.txt           
  error:  invalid compressed data to inflate
  inflating: trailer.txt
```

I looked at it, and attempted a fix — but it didn't help, I don't quite understand why.

(I also don't understand why `empty_OK_2.txt` has compressed length 2, and not 0).

In practice, this wasn't a major issue for us — as there's an easy **workaround**, of wrapping all `ZipDataSource` arguments in a little `(yield "" >>)` in user-code relative to `zip-stream`. But I just thought, as a FOSS courtesy, you would better be made aware. Perhaps you can think of a fix for this that will improve the library.

By all means, feel free to discard this PR, or merge after some reworks — it's really only a bug report, with a patch attached to demonstrate the issue that's quite specific.